### PR TITLE
Blocks

### DIFF
--- a/src/engine/blocks.py
+++ b/src/engine/blocks.py
@@ -30,7 +30,7 @@ class Block(metaclass=ABCMeta):
 class Flat(Block):
 
     @abstractmethod
-    def interact_with_convex(self, convex, direction):
+    def interact_with_convex(self, convex):
         pass
 
 

--- a/src/engine/blocks.py
+++ b/src/engine/blocks.py
@@ -18,9 +18,6 @@ class Block(metaclass=ABCMeta):
         pass
 
     def self_draw(self, frame, x, y, side_length):
-        if not self.is_alive:
-            self.destroy()
-            return
         if self.displayed_side_length != side_length:
             self.displayed_side_length = side_length
             self.displayed_texture = pygame.transform.scale(self.texture, (side_length, side_length)) 

--- a/src/engine/blocks.py
+++ b/src/engine/blocks.py
@@ -10,35 +10,24 @@ class Block(metaclass=ABCMeta):
 
     @staticmethod
     @abstractmethod
-    def texture(self):
+    def texture():
         pass
 
     @abstractmethod
     def interact_with_snake(self, snake):
         pass
 
-    def self_draw(self, frame, x, y, side_length):
+    def self_draw(self, frame, position, side_length):
         if self.displayed_side_length != side_length:
             self.displayed_side_length = side_length
-            self.displayed_texture = pygame.transform.scale(self.texture, (side_length, side_length)) 
-        frame.blit(self.displayed_texture, (x, y))
+            self.displayed_texture = pygame.transform.scale(self.texture(), (side_length, side_length)) 
+        frame.blit(self.displayed_texture, position)
 
     def set_field(self, field):
         self.field = field
 
 
 class Flat(Block):
-    def __init__(self):
-        super().__init__()
-
-    @staticmethod
-    @abstractmethod
-    def texture(self):
-        pass
-
-    @abstractmethod
-    def interact_with_snake(self, snake):
-        pass
 
     @abstractmethod
     def interact_with_convex(self, convex, direction):
@@ -48,15 +37,6 @@ class Flat(Block):
 class Convex(Block):
     def __init__(self):
         super().__init__()
-
-    @staticmethod
-    @abstractmethod
-    def texture(self):
-        pass
-
-    @abstractmethod
-    def interact_with_snake(self, snake):
-        pass
 
     @abstractmethod
     def check_move(self, direction) -> bool:
@@ -70,11 +50,11 @@ class Convex(Block):
     def check_snake_move(self) -> bool:
         pass
 
-    def self_draw(self, frame, x, y, side_length):
+    def self_draw(self, frame, position, side_length):
         if not self.is_alive:
             self.destroy()
             return
-        super().self_draw(frame, x, y, side_length)
+        super().self_draw(frame, position, side_length)
 
     def kill(self):
         self.is_alive = False
@@ -92,8 +72,8 @@ class Wall(Convex):
     def __init__(self):
         super().__init__()
     
-    @property
-    def texture(self):
+    @staticmethod
+    def texture():
         return pygame.image.load('../assets/wall.png')
     
     def check_move(self, direction) -> bool:

--- a/src/engine/blocks.py
+++ b/src/engine/blocks.py
@@ -5,8 +5,10 @@ class Block(metaclass=ABCMeta):
     def __init__(self):
         self.field = None
         self.is_alive = True
+        self.displayed_texture = None
+        self.displayed_side_length = None
 
-    @property
+    @staticmethod
     @abstractmethod
     def texture(self):
         pass
@@ -15,8 +17,14 @@ class Block(metaclass=ABCMeta):
     def interact_with_snake(self, snake):
         pass
 
-    def self_draw(self, frame, x, y):
-        frame.blit(self.texture, (x, y))
+    def self_draw(self, frame, x, y, side_length):
+        if not self.is_alive:
+            self.destroy()
+            return
+        if self.displayed_side_length != side_length:
+            self.displayed_side_length = side_length
+            self.displayed_texture = pygame.transform.scale(self.texture, (side_length, side_length)) 
+        frame.blit(self.displayed_texture, (x, y))
 
     def set_field(self, field):
         self.field = field
@@ -24,9 +32,9 @@ class Block(metaclass=ABCMeta):
 
 class Flat(Block):
     def __init__(self):
-        pass
+        super().__init__()
 
-    @property
+    @staticmethod
     @abstractmethod
     def texture(self):
         pass
@@ -44,7 +52,7 @@ class Convex(Block):
     def __init__(self):
         super().__init__()
 
-    @property
+    @staticmethod
     @abstractmethod
     def texture(self):
         pass
@@ -69,8 +77,7 @@ class Convex(Block):
         if not self.is_alive:
             self.destroy()
             return
-        displayed_texture = pygame.transform.scale(self.texture, (side_length, side_length)) 
-        frame.blit(displayed_texture, (x, y))
+        super().self_draw(frame, x, y, side_length)
 
     def kill(self):
         self.is_alive = False

--- a/tests/unit/test_blocks.py
+++ b/tests/unit/test_blocks.py
@@ -1,116 +1,61 @@
 from src.engine.blocks import Block, Convex, Flat, Wall, WallInteractionError
-from src.engine.direction import Direction
 import pytest
-import pygame
-
+import mock
 
 
 def test_wall_and_snake_cannot_interact():
-    try:
-        Wall().interact_with_snake('snake')
-        assert False
-    except WallInteractionError:
-        assert True
+    snake = mock.Mock()
+    with pytest.raises(WallInteractionError):
+        Wall().interact_with_snake(snake)
 
 
-def test_wall_cannot_be_moved_north():
-    try:
-        Wall().move(Direction('N'))
-        assert False
-    except WallInteractionError:
-        assert True
+def test_wall_cannot_be_moved():
+    direction = mock.Mock()
+    with pytest.raises(WallInteractionError):
+        Wall().move(direction)
 
 
-def test_wall_cannot_be_moved_south():
-    try:
-        Wall().move(Direction('S'))
-        assert False
-    except WallInteractionError:
-        assert True
-
-
-def test_wall_cannot_be_moved_east():
-    try:
-        Wall().move(Direction('E'))
-        assert False
-    except WallInteractionError:
-        assert True
-
-
-def test_wall_cannot_be_moved_west():
-    try:
-        Wall().move(Direction('W'))
-        assert False
-    except WallInteractionError:
-        assert True
-
-
-def test_wall_denies_moving_north():
-    assert not Wall().check_move(Direction('N'))
-
-
-def test_wall_denies_moving_south():
-    assert not Wall().check_move(Direction('S'))
-
-
-def test_wall_denies_moving_east():
-    assert not Wall().check_move(Direction('E'))
-
-
-def test_wall_denies_moving_west():
-    assert not Wall().check_move(Direction('W'))
+def test_wall_denies_moving():
+    direction = mock.Mock()
+    assert not Wall().check_move(direction)
 
 
 def test_snake_cant_move_towards_wall_when_next_to_it():
-    assert not Wall().check_snake_move(Direction('E'))
-    assert not Wall().check_snake_move(Direction('W'))
-    assert not Wall().check_snake_move(Direction('N'))
-    assert not Wall().check_snake_move(Direction('S'))
+    direction = mock.Mock()
+    assert not Wall().check_snake_move(direction)
 
 
 def test_block_class_object_cant_be_created():
-    try:
+    with pytest.raises(TypeError):
         Block()
-        assert False
-    except TypeError:
-        assert True
 
 
 def test_convex_class_object_cant_be_created():
-    try:
+    with pytest.raises(TypeError):
         Convex()
-        assert False
-    except TypeError:
-        assert True
 
 
 def test_flat_class_object_cant_be_created():
-    try:
+    with pytest.raises(TypeError):
         Flat()
-        assert False
-    except TypeError:
-        assert True
 
 
 def test_wall_class_object_can_be_created():
-    try:
-        Wall()
-        assert True
-    except:
-        assert False
+    Wall()
 
 
 def test_wall_class_object_cant_be_killed():
-    try:
+    with pytest.raises(WallInteractionError):
         Wall().kill()
-        assert False
-    except WallInteractionError:
-        assert True
 
 
 def test_wall_class_object_cant_be_destroyed():
-    try:
+    with pytest.raises(WallInteractionError):
         Wall().destroy()
-        assert False
-    except WallInteractionError:
-        assert True
+
+
+def test_wall_set_field():
+    field = mock.Mock()
+    wall = Wall()
+    wall.set_field(field)
+    assert wall.field == field

--- a/tests/unit/test_blocks.py
+++ b/tests/unit/test_blocks.py
@@ -54,8 +54,85 @@ def test_wall_class_object_cant_be_destroyed():
         Wall().destroy()
 
 
-def test_wall_set_field():
+def test_block_class_has_static_empty_method_texture():
+    Block.__abstractmethods__ = set()
+    assert Block.texture() is None
+
+
+def test_block_class_has_empty_method_interact_with_snake():
+    Block.__abstractmethods__ = set()
+    snake = mock.Mock()
+    assert Block().interact_with_snake(snake) is None
+
+
+def test_block_class_set_field():
     field = mock.Mock()
-    wall = Wall()
-    wall.set_field(field)
-    assert wall.field == field
+    Block.__abstractmethods__ = set()
+    block = Block()
+    block.set_field(field)
+    assert block.field == field
+
+
+def test_flat_class_has_empty_method_interact_with_convex():
+    Flat.__abstractmethods__ = set()
+    convex = mock.Mock()
+    direction = mock.Mock()
+    assert Flat().interact_with_convex(convex, direction) is None
+
+
+def test_convex_class_has_empty_method_move():
+    Convex.__abstractmethods__ = set()
+    direction = mock.Mock()
+    assert Convex().move(direction) is None
+
+
+def test_convex_class_has_empty_method_check_snake_move():
+    Convex.__abstractmethods__ = set()
+    assert Convex().check_snake_move() is None
+
+
+def test_convex_class_has_empty_method_check_move():
+    Convex.__abstractmethods__ = set()
+    direction = mock.Mock()
+    assert Convex().check_move(direction) is None
+
+
+def test_block_self_draw_when_drawing_same_size_as_remembered():
+    Block().__abstractmethods__ = set()
+    #def self_draw(self, frame, position, side_length):
+    frame = mock.Mock()
+    position = mock.Mock()
+    displayed_texture = mock.Mock()
+    block = Block()
+    block.displayed_side_length = 10
+    block.displayed_texture = displayed_texture
+    block.self_draw(frame, position, 10)
+    assert block.displayed_texture == displayed_texture
+    frame.blit.assert_called_once_with(displayed_texture, position)
+
+
+def test_convex_that_is_not_alive_self_draw_wont_draw_in_frame_and_will_be_removed_from_its_field():
+    Convex().__abstractmethods__ = set()
+    convex = Convex()
+    convex.is_alive = False
+    frame = mock.Mock()
+    position = mock.Mock()
+    field = mock.Mock()
+    convex.field = field
+    convex.self_draw(frame, position, 77)
+    field.remove_convex.assert_called_once()
+    assert not frame.blit.called
+
+
+def test_convex_that_is_alive_self_draw_will_draw_in_frame_when_remembered_size_equals_current_one():
+    Convex().__abstractmethods__ = set()
+    convex = Convex()
+    convex.is_alive = True
+    frame = mock.Mock()
+    position = mock.Mock()
+    field = mock.Mock()
+    convex.field = field
+    convex.displayed_side_length = 1234
+    convex.self_draw(frame, position, 1234)
+    frame.blit.assert_called_once()
+

--- a/tests/unit/test_blocks.py
+++ b/tests/unit/test_blocks.py
@@ -98,7 +98,6 @@ def test_convex_class_has_empty_method_check_move():
 
 def test_block_self_draw_when_drawing_same_size_as_remembered():
     Block().__abstractmethods__ = set()
-    #def self_draw(self, frame, position, side_length):
     frame = mock.Mock()
     position = mock.Mock()
     displayed_texture = mock.Mock()

--- a/tests/unit/test_blocks.py
+++ b/tests/unit/test_blocks.py
@@ -76,8 +76,7 @@ def test_block_class_set_field():
 def test_flat_class_has_empty_method_interact_with_convex():
     Flat.__abstractmethods__ = set()
     convex = mock.Mock()
-    direction = mock.Mock()
-    assert Flat().interact_with_convex(convex, direction) is None
+    assert Flat().interact_with_convex(convex) is None
 
 
 def test_convex_class_has_empty_method_move():


### PR DESCRIPTION
more unit tests
position as tuple instead of two arguments
removed unnecessary abstract methods inherited from parent classes